### PR TITLE
Performance: Implement equivalent of upstream PR 413

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ Using `89283080dcbffff` (Uber's SF Test index @ resolution 9) to get all childre
 |                                Method |     Mean |     Error |    StdDev |     Gen 0 |     Gen 1 |    Gen 2 | Allocated |
 |-------------------------------------- |---------:|----------:|----------:|----------:|----------:|---------:|----------:|
 | pocketken.H3.GetChildrenForResolution | 9.368 ms | 0.1335 ms | 0.1184 ms |  796.8750 |  781.2500 | 484.3750 |   4.69 MB |
-|                      H3Lib.ToChildren | 9.923 ms | 0.1932 ms | 0.3280 ms | 3453.1250 | 1656.2500 | 984.3750 |  23.55 MB |
-
+|                      H3Lib.ToChildren | 9.689 ms | 0.1837 ms | 0.1966 ms | 3453.1250 | 1640.6250 | 984.3750 |  23.55 MB |
 
 ### Lines
 Line from `8e283080dc80007` to `8e48e1d7038d527` (`DistanceTo` of 554,625 cells).

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ While there are some comparisons here against [H3Lib](https://github.com/Richard
 #### GetChildrenForResolution
 Using `89283080dcbffff` (Uber's SF Test index @ resolution 9) to get all children at resolution 15.
 
-|                                Method |      Mean |     Error |    StdDev |     Gen 0 |     Gen 1 |    Gen 2 | Allocated |
-|-------------------------------------- |----------:|----------:|----------:|----------:|----------:|---------:|----------:|
-| pocketken.H3.GetChildrenForResolution | 10.275 ms | 0.2009 ms | 0.2681 ms |  890.6250 |  796.8750 | 546.8750 |   5.64 MB |
-|                      H3Lib.ToChildren |  9.689 ms | 0.1837 ms | 0.1966 ms | 3453.1250 | 1640.6250 | 984.3750 |  23.55 MB |
+|                                Method |     Mean |     Error |    StdDev |     Gen 0 |     Gen 1 |    Gen 2 | Allocated |
+|-------------------------------------- |---------:|----------:|----------:|----------:|----------:|---------:|----------:|
+| pocketken.H3.GetChildrenForResolution | 9.406 ms | 0.1618 ms | 0.1514 ms |  796.8750 |  781.2500 | 484.3750 |   4.69 MB |
+|                      H3Lib.ToChildren | 9.923 ms | 0.1932 ms | 0.3280 ms | 3453.1250 | 1656.2500 | 984.3750 |  23.55 MB |
 
 
 ### Lines

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Using `89283080dcbffff` (Uber's SF Test index @ resolution 9) to get all childre
 
 |                                Method |     Mean |     Error |    StdDev |     Gen 0 |     Gen 1 |    Gen 2 | Allocated |
 |-------------------------------------- |---------:|----------:|----------:|----------:|----------:|---------:|----------:|
-| pocketken.H3.GetChildrenForResolution | 9.406 ms | 0.1618 ms | 0.1514 ms |  796.8750 |  781.2500 | 484.3750 |   4.69 MB |
+| pocketken.H3.GetChildrenForResolution | 9.368 ms | 0.1335 ms | 0.1184 ms |  796.8750 |  781.2500 | 484.3750 |   4.69 MB |
 |                      H3Lib.ToChildren | 9.923 ms | 0.1932 ms | 0.3280 ms | 3453.1250 | 1656.2500 | 984.3750 |  23.55 MB |
 
 

--- a/src/H3/Extensions/H3HierarchyExtensions.cs
+++ b/src/H3/Extensions/H3HierarchyExtensions.cs
@@ -309,10 +309,11 @@ namespace H3.Extensions {
                 yield break;
             }
 
-            // initialize our iterator
-            H3Index iterator = new(origin);
+            // initialize our iterator by starting at the center child at the target resolution
+            H3Index iterator = new(origin) {
+                Resolution = childResolution
+            };
             iterator.ZeroDirectionsForResolutionRange(parentResolution + 1, childResolution);
-            iterator.Resolution = childResolution;
 
             // handle pentagons
             int fnz = iterator.IsPentagon ? childResolution : -1;
@@ -324,13 +325,16 @@ namespace H3.Extensions {
                 iterator.IncrementDirectionForResolution(childRes);
 
                 for (int i = childResolution; i >= parentResolution; i -= 1) {
+                    // done iterating?
                     if (i == parentResolution) {
                         iterator = H3Index.Invalid;
                         break;
                     }
 
+                    Direction dir = iterator.GetDirectionForResolution(i);
+
                     // pentagon?
-                    if (i == fnz && iterator.GetDirectionForResolution(i) == Direction.K) {
+                    if (i == fnz && dir == Direction.K) {
                         // Then we are iterating through the children of a pentagon cell.
                         // All children of a pentagon have the property that the first
                         // nonzero digit between the parent and child resolutions is
@@ -342,7 +346,8 @@ namespace H3.Extensions {
                         break;
                     }
 
-                    if (iterator.GetDirectionForResolution(i) == Direction.Invalid) {
+                    if (dir == Direction.Invalid) {
+                        // zeros out it[i] and increments it[i-1] by 1
                         iterator.IncrementDirectionForResolution(i);
                     } else {
                         break;

--- a/src/H3/H3Index.cs
+++ b/src/H3/H3Index.cs
@@ -223,6 +223,34 @@ namespace H3 {
         }
 
         /// <summary>
+        /// Increments the Direction "digit" for the index at the specified resolution.
+        /// </summary>
+        /// <param name="resolution"></param>
+        public void IncrementDirectionForResolution(int resolution) {
+            ulong val = 1UL;
+            val <<= 3 * (15 - resolution);
+            Value += val;
+        }
+
+        /// <summary>
+        /// Zeros the Direction "digits" for the indexes starting at startResolution
+        /// and ending at endResolution.
+        /// </summary>
+        /// <param name="startResolution"></param>
+        /// <param name="endResolution"></param>
+        public void ZeroDirectionsForResolutionRange(int startResolution, int endResolution) {
+            if (startResolution > endResolution) return;
+
+            ulong m = ~0UL;
+            m <<= 3 * (endResolution - startResolution + 1);
+            m = ~m;
+            m <<= 3 * (15 - endResolution);
+            m = ~m;
+
+            Value &= m;
+        }
+
+        /// <summary>
         /// Rotates the index in place; skips any leading 1 digits (k-axis)
         /// </summary>
         /// <param name="rotateIndex">Callback to be fired in order to actually perform


### PR DESCRIPTION
Slight improvements to `GetChildrenForResolution` based upon upstream [PR 413](https://github.com/uber/h3/pull/413).