### PR TITLE
Performance: inline them all!!1!

### DIFF
--- a/src/H3/H3Index.cs
+++ b/src/H3/H3Index.cs
@@ -5,6 +5,7 @@ using static H3.Constants;
 using static H3.Utils;
 using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
+using System.Runtime.CompilerServices;
 
 #nullable enable
 
@@ -50,13 +51,18 @@ namespace H3 {
 
         private ulong Value { get; set; } = 0;
 
-        public BaseCell BaseCell => LookupTables.BaseCells[BaseCellNumber];
+        public BaseCell BaseCell {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => LookupTables.BaseCells[BaseCellNumber];
+        }
 
         /// <summary>
         /// The highest bit value of the index.
         /// </summary>
         public int HighBit {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => (int)((Value & H3_HIGH_BIT_MASK) >> H3_MAX_OFFSET);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => Value = (Value & H3_HIGH_BIT_MASK_NEGATIVE) | ((ulong)value << H3_MAX_OFFSET);
         }
 
@@ -64,7 +70,9 @@ namespace H3 {
         /// The Mode of the index.
         /// </summary>
         public Mode Mode {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => (Mode)((Value & H3_MODE_MASK) >> H3_MODE_OFFSET);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => Value = (Value & H3_MODE_MASK_NEGATIVE) | ((ulong)value << H3_MODE_OFFSET);
         }
 
@@ -72,7 +80,9 @@ namespace H3 {
         /// The base cell number of the index.  Must be >= 0 < NUM_BASE_CELLS
         /// </summary>
         public int BaseCellNumber {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => (int)((Value & H3_BC_MASK) >> H3_BC_OFFSET);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => Value = (Value & H3_BC_MASK_NEGATIVE) | ((ulong)value << H3_BC_OFFSET);
         }
 
@@ -80,7 +90,9 @@ namespace H3 {
         /// The resolution of the index.  Must be >= 0 <= MAX_H3_RES
         /// </summary>
         public int Resolution {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => (int)((Value & H3_RES_MASK) >> H3_RES_OFFSET);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => Value = (Value & H3_RES_MASK_NEGATIVE) | ((ulong)value << H3_RES_OFFSET);
         }
 
@@ -98,7 +110,9 @@ namespace H3 {
         /// the index.
         /// </summary>
         public int ReservedBits {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => (int)((Value & H3_RESERVED_MASK) >> H3_RESERVED_OFFSET);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => Value = (Value & H3_RESERVED_MASK_NEGATIVE) | ((ulong)value << H3_RESERVED_OFFSET);
         }
 
@@ -144,6 +158,7 @@ namespace H3 {
         /// The leading non-zero Direction "digit" of the index.
         /// </summary>
         public Direction LeadingNonZeroDirection {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get {
                 int resolution = Resolution;
                 for (int r = 1; r <= resolution; r += 1) {
@@ -160,8 +175,10 @@ namespace H3 {
         /// <summary>
         /// Whether or not this index should be considered as a pentagon.
         /// </summary>
-        public bool IsPentagon => BaseCell.IsPentagon &&
-            LeadingNonZeroDirection == Direction.Center;
+        public bool IsPentagon {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => BaseCell.IsPentagon && LeadingNonZeroDirection == Direction.Center;
+        }
 
         /// <summary>
         /// The maximum number of possible icosahedron faces the index
@@ -203,6 +220,7 @@ namespace H3 {
         /// </summary>
         /// <param name="resolution"></param>
         /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Direction GetDirectionForResolution(int resolution) {
             var v = (int)((Value >> ((MAX_H3_RES - resolution) * H3_PER_DIGIT_OFFSET)) & H3_DIGIT_MASK);
             return (Direction)v;
@@ -214,6 +232,7 @@ namespace H3 {
         /// </summary>
         /// <param name="resolution"></param>
         /// <param name="direction"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetDirectionForResolution(int resolution, Direction direction) {
             int offset = (MAX_H3_RES - resolution) * H3_PER_DIGIT_OFFSET;
             Value = (Value & ~(H3_DIGIT_MASK << (offset))) |
@@ -224,6 +243,7 @@ namespace H3 {
         /// Increments the Direction "digit" for the index at the specified resolution.
         /// </summary>
         /// <param name="resolution"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void IncrementDirectionForResolution(int resolution) {
             ulong val = 1UL;
             val <<= 3 * (15 - resolution);
@@ -236,6 +256,7 @@ namespace H3 {
         /// </summary>
         /// <param name="startResolution"></param>
         /// <param name="endResolution"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ZeroDirectionsForResolutionRange(int startResolution, int endResolution) {
             if (startResolution > endResolution) return;
 


### PR DESCRIPTION
Seems hokey to have to tell the compiler to inline accessors, and obviously leads to a larger build output (`.dll` is roughly 2x the size  or so), but it seems to make for some ok gains given how often the accessors are used throughout the library?

* before AggressiveInlining

|                                            Method |      Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------------------------- |----------:|---------:|---------:|------:|------:|------:|----------:|
|         pocketken.H3.H3Index.RotateClockwise(hex) | 147.38 ns | 1.142 ns | 1.068 ns |     - |     - |     - |         - |
|  pocketken.H3.H3Index.RotateCounterClockwise(hex) | 138.16 ns | 0.681 ns | 0.604 ns |     - |     - |     - |         - |
|        pocketken.H3.H3Index.RotateClockwise(pent) |  74.40 ns | 0.865 ns | 0.767 ns |     - |     - |     - |         - |
| pocketken.H3.H3Index.RotateCounterClockwise(pent) |  70.87 ns | 0.608 ns | 0.569 ns |     - |     - |     - |         - |
| &#39;pocketken.H3.GetKRingFast(hex, k = 50)&#39; |   593.2 us |  4.04 us |  3.78 us |  66.4063 | 33.2031 |       - |  547.92 KB |
| &#39;pocketken.H3.GetKRingSlow(hex, k = 50)&#39; | 5,846.9 us | 26.14 us | 24.45 us | 179.6875 | 85.9375 | 85.9375 | 1634.09 KB |
|  pocketken.H3.Compact |  356.1 ms | 6.75 ms | 6.63 ms | 11000.0000 | 3000.0000 |         - | 243.51 MB |


* after AggressiveInlining

|                                            Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------------------------- |---------:|---------:|---------:|------:|------:|------:|----------:|
|         pocketken.H3.H3Index.RotateClockwise(hex) | 58.46 ns | 0.373 ns | 0.311 ns |     - |     - |     - |         - |
|  pocketken.H3.H3Index.RotateCounterClockwise(hex) | 64.83 ns | 0.737 ns | 0.690 ns |     - |     - |     - |         - |
|        pocketken.H3.H3Index.RotateClockwise(pent) | 28.37 ns | 0.027 ns | 0.022 ns |     - |     - |     - |         - |
| pocketken.H3.H3Index.RotateCounterClockwise(pent) | 28.38 ns | 0.306 ns | 0.271 ns |     - |     - |     - |         - |
|  &#39;pocketken.H3.GetKRingFast(hex, k = 50)&#39; |   438.1 μs |  4.23 μs |  3.75 μs |  66.4063 | 33.2031 |       - |  547.92 KB |
|  &#39;pocketken.H3.GetKRingSlow(hex, k = 50)&#39; | 3,820.5 μs | 23.49 μs | 20.83 μs | 179.6875 | 89.8438 | 89.8438 | 1634.09 KB |
| pocketken.H3.Compact | 333.2 ms | 3.96 ms | 3.70 ms | 11000.0000 | 3000.0000 |         - | 243.51 MB |

Will put them in place for now until someone smarter comes along and can provide some better guidance on what we should/shouldn't be doing here...  Definitely feels a bit excessive and dirty to have to do this.