### PR TITLE
More minor optimizations; cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,21 @@ While there are some comparisons here against [H3Lib](https://github.com/Richard
 
 ### Hierarchy Ops
 
+### GetParentForResolution
+Using `89283080dcbffff` (Uber's SF Test index @ resolution 9) to get parent at resolution 0 (a silly microbenchmark):
+
+|                              Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|------------------------------------ |----------:|----------:|----------:|-------:|------:|------:|----------:|
+| pocketken.H3.GetParentForResolution |  4.458 ns | 0.0474 ns | 0.0443 ns | 0.0029 |     - |     - |      24 B |
+|                      H3Lib.ToParent | 20.817 ns | 0.1196 ns | 0.1118 ns |      - |     - |     - |         - |
+
 #### GetChildrenForResolution
 Using `89283080dcbffff` (Uber's SF Test index @ resolution 9) to get all children at resolution 15.
 
 |                                Method |     Mean |     Error |    StdDev |     Gen 0 |     Gen 1 |    Gen 2 | Allocated |
 |-------------------------------------- |---------:|----------:|----------:|----------:|----------:|---------:|----------:|
-| pocketken.H3.GetChildrenForResolution | 9.368 ms | 0.1335 ms | 0.1184 ms |  796.8750 |  781.2500 | 484.3750 |   4.69 MB |
-|                      H3Lib.ToChildren | 9.689 ms | 0.1837 ms | 0.1966 ms | 3453.1250 | 1640.6250 | 984.3750 |  23.55 MB |
+| pocketken.H3.GetChildrenForResolution | 9.128 ms | 0.1809 ms | 0.2415 ms |  796.8750 |  781.2500 | 484.3750 |   4.69 MB |
+|                      H3Lib.ToChildren | 9.671 ms | 0.1904 ms | 0.2266 ms | 3453.1250 | 1671.8750 | 984.3750 |  23.55 MB |
 
 ### Lines
 Line from `8e283080dc80007` to `8e48e1d7038d527` (`DistanceTo` of 554,625 cells).
@@ -63,26 +71,28 @@ Line from `8e283080dc80007` to `8e48e1d7038d527` (`DistanceTo` of 554,625 cells)
 ### Rings
 `hex` is a hexagon index (`8f48e1d7038d520`).
 
-|                                   Method |       Mean |    Error |   StdDev |   Gen 0 |    Gen 1 |   Gen 2 |  Allocated |
-|----------------------------------------- |-----------:|---------:|---------:|--------:|---------:|--------:|-----------:|
-| 'pocketken.H3.GetKRingFast(hex, k = 50)' |   593.2 us |  4.04 us |  3.78 us |  66.4063 | 33.2031 |       - |  547.92 KB |
-| 'pocketken.H3.GetKRingSlow(hex, k = 50)' | 5,846.9 us | 26.14 us | 24.45 us | 179.6875 | 85.9375 | 85.9375 | 1634.09 KB |
-|      'H3Lib.KRingDistances(hex, k = 50)' |   377.3 us |  1.83 us |  1.53 us |  99.6094 | 99.6094 | 99.6094 |  486.59 KB |
+|                                   Method |       Mean |    Error |   StdDev |    Gen 0 |   Gen 1 |   Gen 2 |  Allocated |
+|----------------------------------------- |-----------:|---------:|---------:|---------:|--------:|--------:|-----------:|
+|     'pocketken.H3.GetKRing(hex, k = 50)' |   460.1 us |  1.99 us |  1.86 us |  73.7305 | 36.6211 |       - |  607.75 KB |
+| 'pocketken.H3.GetKRingFast(hex, k = 50)' |   471.4 us |  2.48 us |  2.32 us |  66.4063 | 33.2031 |       - |  547.92 KB |
+| 'pocketken.H3.GetKRingSlow(hex, k = 50)' | 4,852.8 us | 38.70 us | 36.20 us | 179.6875 | 85.9375 | 85.9375 | 1634.09 KB |
+|      'H3Lib.KRingDistances(hex, k = 50)' |   381.6 us |  0.87 us |  0.68 us |  99.6094 | 99.6094 | 99.6094 |  486.59 KB |
 
 `pent` is a pentagon index (`8e0800000000007`) which forces the use of the iterative (recursive in the case of H3Lib) method of generating the ring due to the fast method's inability to handle pentagons.
 
-|                                    Method |          Mean |         Error |        StdDev |        Gen 0 |        Gen 1 |        Gen 2 |   Allocated |
-|------------------------------------------ |--------------:|--------------:|--------------:|-------------:|-------------:|-------------:|------------:|
-| 'pocketken.H3.GetKRingSlow(pent, k = 50)' |      5.644 ms |     0.0249 ms |     0.0233 ms |     179.6875 |      85.9375 |      85.9375 |      1.6 MB |
-|      'H3Lib.KRingDistances(pent, k = 50)' | 59,581.867 ms | 1,123.9235 ms | 1,154.1867 ms | 7683000.0000 | 6097000.0000 | 5055000.0000 | 71357.79 MB |
+|                                    Method |          Mean |       Error |      StdDev |        Gen 0 |        Gen 1 |        Gen 2 |   Allocated |
+|------------------------------------------ |--------------:|------------:|------------:|-------------:|-------------:|-------------:|------------:|
+|     'pocketken.H3.GetKRing(pent, k = 50)' |      4.088 ms |   0.0263 ms |   0.0246 ms |     179.6875 |      85.9375 |      85.9375 |      1.6 MB |
+| 'pocketken.H3.GetKRingSlow(pent, k = 50)' |      3.985 ms |   0.0138 ms |   0.0115 ms |     179.6875 |      85.9375 |      85.9375 |      1.6 MB |
+|      'H3Lib.KRingDistances(pent, k = 50)' | 59,216.102 ms | 960.4448 ms | 898.4006 ms | 7692000.0000 | 6112000.0000 | 5064000.0000 | 71358.66 MB |
 
 ### Sets
-* Compact: Result of compacting all base cells at resolution 5.
+* Compact: Result of compacting all cells at resolution 5.
 * Uncompact: Result of uncompacting all base cells to resolution of 5.
 
-|                Type |                 Method |     Mean |    Error |  StdDev |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
-|-------------------- |----------------------- |----------:|--------:|--------:|-----------:|----------:|----------:|----------:|
-|   CompactBenchmarks |   pocketken.H3.Compact |  356.1 ms | 6.75 ms | 6.63 ms | 11000.0000 | 3000.0000 |         - | 243.51 MB |
-|   CompactBenchmarks |          H3Lib.Compact |  389.1 ms | 6.56 ms | 6.14 ms |  9000.0000 | 4000.0000 | 2000.0000 | 305.24 MB |
-| UncompactBenchmarks | pocketken.H3.Uncompact |  138.7 ms | 1.45 ms | 1.36 ms |  6500.0000 | 3500.0000 | 1000.0000 |  78.18 MB |
-| UncompactBenchmarks |        H3Lib.Uncompact |  194.9 ms | 1.97 ms | 1.75 ms | 43000.0000 | 7333.3333 |  666.6667 | 493.02 MB |
+|                 Method |     Mean |   Error |  StdDev |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
+|----------------------- |---------:|--------:|--------:|-----------:|----------:|----------:|----------:|
+|   pocketken.H3.Compact | 330.3 ms | 5.50 ms | 5.14 ms | 11000.0000 | 3000.0000 |         - | 243.51 MB |
+|          H3Lib.Compact | 381.0 ms | 5.83 ms | 5.45 ms |  9000.0000 | 4000.0000 | 2000.0000 | 305.24 MB |
+| pocketken.H3.Uncompact | 136.6 ms | 0.36 ms | 0.32 ms |  6500.0000 | 3500.0000 | 1000.0000 |  78.18 MB |
+|        H3Lib.Uncompact | 203.3 ms | 4.05 ms | 4.16 ms | 43000.0000 | 7333.3333 |  666.6667 | 493.02 MB |

--- a/src/H3/Algorithms/Rings.cs
+++ b/src/H3/Algorithms/Rings.cs
@@ -62,7 +62,7 @@ namespace H3.Algorithms {
             // break out to the requested ring
             int rotations = 0;
             for (int ring = 0; ring < k; ring +=1 ) {
-                index = index.GetDirectNeighbour(LookupTables.NextRingDirection, ref rotations);
+                (index, rotations) = index.GetDirectNeighbour(LookupTables.NextRingDirection, rotations);
                 if (index == H3Index.Invalid) throw new HexRingKSequenceException();
                 if (index.IsPentagon) throw new HexRingPentagonException();
             }
@@ -72,7 +72,7 @@ namespace H3.Algorithms {
 
             for (int direction = 0; direction < 6; direction += 1) {
                 for (int pos = 0; pos < k; pos += 1) {
-                    index = index.GetDirectNeighbour(LookupTables.CounterClockwiseDirections[direction], ref rotations);
+                    (index, rotations) = index.GetDirectNeighbour(LookupTables.CounterClockwiseDirections[direction], rotations);
                     if (index == H3Index.Invalid) throw new HexRingKSequenceException();
 
                     // Skip the very last index, it was already added. We do
@@ -135,8 +135,7 @@ namespace H3.Algorithms {
                 var nextK = cell.Distance + 1;
                 if (nextK <= k) {
                     for (int i = 0; i < 6; i += 1) {
-                        int rotations = 0;
-                        var neighbour = cell.Index.GetDirectNeighbour(LookupTables.CounterClockwiseDirections[i], ref rotations);
+                        var neighbour = cell.Index.GetDirectNeighbour(LookupTables.CounterClockwiseDirections[i]).Item1;
                         if (neighbour == origin || neighbour == H3Index.Invalid || (searched.TryGetValue(neighbour, out int previousK) && previousK <= nextK)) {
                             continue;
                         }
@@ -190,7 +189,7 @@ namespace H3.Algorithms {
                 if (direction == 0 && i == 0) {
                     // Not putting in the output set as it will be done later, at
                     // the end of this ring.
-                    index = index.GetDirectNeighbour(LookupTables.NextRingDirection, ref rotations);
+                    (index, rotations) = index.GetDirectNeighbour(LookupTables.NextRingDirection, rotations);
                     if (index == H3Index.Invalid) {
                         // Should not be possible because `origin` would have to be a pentagon
                         throw new HexRingKSequenceException();
@@ -202,7 +201,7 @@ namespace H3.Algorithms {
                     }
                 }
 
-                index = index.GetDirectNeighbour(LookupTables.CounterClockwiseDirections[direction], ref rotations);
+                (index, rotations) = index.GetDirectNeighbour(LookupTables.CounterClockwiseDirections[direction], rotations);
                 if (index == H3Index.Invalid) {
                     // Should not be possible because `origin` would have to be a pentagon
                     throw new HexRingKSequenceException();

--- a/src/H3/Extensions/H3HierarchyExtensions.cs
+++ b/src/H3/Extensions/H3HierarchyExtensions.cs
@@ -29,7 +29,7 @@ namespace H3.Extensions {
         /// (such as when crossing a face edge.)</param>
         /// <returns>H3Index of the specified neighbor or H3_NULL if deleted k-subsequence
         /// distortion is encountered.</returns>
-        public static H3Index GetDirectNeighbour(this H3Index origin, Direction direction, ref int rotations) {
+        public static (H3Index, int) GetDirectNeighbour(this H3Index origin, Direction direction, int rotations = 0) {
             H3Index outIndex = new(origin);
 
             Direction dir = direction;
@@ -116,7 +116,7 @@ namespace H3.Extensions {
                         // base cell.
                         if (oldLeadingDir == Direction.Center) {
                             // Undefined: the k direction is deleted from here
-                            return H3Index.Invalid;
+                            return (H3Index.Invalid, rotations);
                         } else if (oldLeadingDir == Direction.JK) {
                             // Rotate out of the deleted k subsequence
                             // We also need an additional change to the direction we're
@@ -131,7 +131,7 @@ namespace H3.Extensions {
                             rotations += 5;
                         } else {
                             // should never happen
-                            return H3Index.Invalid;
+                            return (H3Index.Invalid, rotations);
                         }
                     }
                 }
@@ -159,7 +159,7 @@ namespace H3.Extensions {
 
             rotations = (rotations + newRotations) % 6;
 
-            return outIndex;
+            return (outIndex, rotations);
         }
 
         /// <summary>
@@ -177,8 +177,7 @@ namespace H3.Extensions {
             bool isPentagon = origin.IsPentagon;
 
             for (Direction dir = isPentagon ? Direction.J : Direction.K; dir < Direction.Invalid; dir += 1) {
-                int rotations = 0;
-                H3Index neighbour = origin.GetDirectNeighbour(dir, ref rotations);
+                var neighbour = origin.GetDirectNeighbour(dir).Item1;
                 if (neighbour == destination) return dir;
             }
 
@@ -251,9 +250,8 @@ namespace H3.Extensions {
             H3Index parentIndex = new(origin) {
                 Resolution = parentResolution
             };
+            parentIndex.InvalidateDirectionsForResolutionRange(parentResolution + 1, resolution);
 
-            for (int r = parentResolution + 1; r <= resolution; r += 1)
-                parentIndex.SetDirectionForResolution(r, Direction.Invalid);
             return parentIndex;
         }
 

--- a/src/H3/Extensions/H3UniEdgeExtensions.cs
+++ b/src/H3/Extensions/H3UniEdgeExtensions.cs
@@ -85,8 +85,7 @@ namespace H3.Extensions {
             if (origin == H3Index.Invalid) {
                 return H3Index.Invalid;
             }
-            int rotations = 0;
-            return origin.GetDirectNeighbour((Direction)edge.ReservedBits, ref rotations);
+            return origin.GetDirectNeighbour((Direction)edge.ReservedBits).Item1;
         }
 
         /// <summary>

--- a/src/H3/Extensions/H3VertexExtensions.cs
+++ b/src/H3/Extensions/H3VertexExtensions.cs
@@ -200,8 +200,7 @@ namespace H3.Extensions {
                     return H3Index.Invalid;
                 }
 
-                int lRotations = 0;
-                H3Index leftNeighbour = cell.GetDirectNeighbour(left, ref lRotations);
+                var (leftNeighbour, lRotations) = cell.GetDirectNeighbour(left);
 
                 // Set to owner if lowest index
                 if (leftNeighbour < owner) {
@@ -218,8 +217,7 @@ namespace H3.Extensions {
                         return H3Index.Invalid;
                     }
 
-                    int rRotations = 0;
-                    H3Index rightNeighbour = cell.GetDirectNeighbour(right, ref rRotations);
+                    var (rightNeighbour, rRotations) = cell.GetDirectNeighbour(right);
 
                     // Set to owner if lowest index
                     if (rightNeighbour < owner) {

--- a/src/H3/H3Index.cs
+++ b/src/H3/H3Index.cs
@@ -48,7 +48,7 @@ namespace H3 {
 
         #region properties
 
-        private ulong Value { get; set; } = 0;
+        internal ulong Value { get; set; } = 0;
 
         public BaseCell BaseCell {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -243,9 +243,9 @@ namespace H3 {
         /// </summary>
         /// <param name="resolution"></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void IncrementDirectionForResolution(int resolution) {
+        internal void IncrementDirectionForResolution(int resolution) {
             ulong val = 1UL;
-            val <<= 3 * (15 - resolution);
+            val <<= H3_PER_DIGIT_OFFSET * (15 - resolution);
             Value += val;
         }
 
@@ -256,16 +256,34 @@ namespace H3 {
         /// <param name="startResolution"></param>
         /// <param name="endResolution"></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ZeroDirectionsForResolutionRange(int startResolution, int endResolution) {
+        internal void ZeroDirectionsForResolutionRange(int startResolution, int endResolution) {
             if (startResolution > endResolution) return;
 
             ulong m = ~0UL;
-            m <<= 3 * (endResolution - startResolution + 1);
+            m <<= H3_PER_DIGIT_OFFSET * (endResolution - startResolution + 1);
             m = ~m;
-            m <<= 3 * (15 - endResolution);
+            m <<= H3_PER_DIGIT_OFFSET * (15 - endResolution);
             m = ~m;
 
             Value &= m;
+        }
+
+        /// <summary>
+        /// Invalidates the Direction "digits" for the indexes starting at startResolution
+        /// and ending at endResolution
+        /// </summary>
+        /// <param name="startResolution"></param>
+        /// <param name="endResolution"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void InvalidateDirectionsForResolutionRange(int startResolution, int endResolution) {
+            if (startResolution > endResolution) return;
+
+            ulong m = ~0UL;
+            m <<= H3_PER_DIGIT_OFFSET * (endResolution - startResolution + 1);
+            m = ~m;
+            m <<= H3_PER_DIGIT_OFFSET * (15 - endResolution);
+
+            Value |= m;
         }
 
         /// <summary>
@@ -544,7 +562,7 @@ namespace H3 {
 
         public static implicit operator ulong(H3Index index) => index.Value;
 
-        public static implicit operator H3Index(ulong value) => new H3Index(value);
+        public static implicit operator H3Index(ulong value) => new(value);
 
         public override string ToString() => $"{Value:x}".ToLowerInvariant();
 

--- a/src/H3/Model/BaseCell.cs
+++ b/src/H3/Model/BaseCell.cs
@@ -32,7 +32,7 @@ namespace H3.Model {
         }
 
         public static implicit operator BaseCell(((int, (int, int, int)), int, (int, int)) tuple) =>
-            new BaseCell {
+            new() {
                 Home = new FaceIJK(tuple.Item1.Item1, tuple.Item1.Item2),
                 IsPentagon = tuple.Item2 == 1,
                 ClockwiseOffsetPent = new int[2] { tuple.Item3.Item1, tuple.Item3.Item2 }

--- a/src/H3/Model/BaseCellRotation.cs
+++ b/src/H3/Model/BaseCellRotation.cs
@@ -15,7 +15,7 @@ namespace H3.Model {
         private BaseCellRotation() { }
 
         public static implicit operator BaseCellRotation((int, int) tuple) =>
-            new BaseCellRotation {
+            new() {
                 Cell = tuple.Item1,
                 CounterClockwiseRotations = tuple.Item2
             };

--- a/src/H3/Model/CoordIJ.cs
+++ b/src/H3/Model/CoordIJ.cs
@@ -20,13 +20,13 @@ namespace H3.Model {
             J = source.J;
         }
 
-        public static CoordIJ FromCoordIJK(CoordIJK ijk) => new CoordIJ {
+        public static CoordIJ FromCoordIJK(CoordIJK ijk) => new() {
             I = ijk.I - ijk.K,
             J = ijk.J - ijk.K
         };
 
         public static implicit operator CoordIJ((int, int) coord) =>
-            new CoordIJ(coord.Item1, coord.Item2);
+            new(coord.Item1, coord.Item2);
 
         public CoordIJK ToCoordIJK() => new CoordIJK(I, J, 0).Normalize();
 

--- a/src/H3/Model/FaceIJK.cs
+++ b/src/H3/Model/FaceIJK.cs
@@ -217,7 +217,7 @@ namespace H3.Model {
             // convert each vertex to lat/lon
             // adjust the face of each vertex as appropriate and introduce
             // edge-crossing vertices as needed
-            FaceIJK lastFijk = new FaceIJK();
+            FaceIJK lastFijk = new();
 
             for (int vert = start; vert < start + length + additionalIteration; vert += 1) {
                 int v = vert % NUM_PENT_VERTS;

--- a/src/H3/Model/FaceOrientIJK.cs
+++ b/src/H3/Model/FaceOrientIJK.cs
@@ -23,7 +23,7 @@ namespace H3.Model {
         }
 
         public static implicit operator FaceOrientIJK((int, (int, int, int), int) args) =>
-            new FaceOrientIJK(args.Item1, args.Item2, args.Item3);
+            new(args.Item1, args.Item2, args.Item3);
 
         public static bool operator ==(FaceOrientIJK a, FaceOrientIJK b) =>
             a.Face == b.Face && a.Translate == b.Translate && a.CounterClockwiseRotations == b.CounterClockwiseRotations;

--- a/src/H3/Model/GeoCoord.cs
+++ b/src/H3/Model/GeoCoord.cs
@@ -31,7 +31,7 @@ namespace H3.Model {
         /// </summary>
         /// <param name="p"></param>
         /// <returns></returns>
-        public static GeoCoord FromPoint(Point p) => new GeoCoord {
+        public static GeoCoord FromPoint(Point p) => new() {
             Latitude = p.Y * M_PI_180,
             Longitude = p.X * M_PI_180
         };
@@ -54,7 +54,7 @@ namespace H3.Model {
         /// The spherical coordinates at the desired azimuth and distance from p1
         /// </returns>
         public static GeoCoord ForAzimuthDistanceInRadians(GeoCoord p1, double azimuth, double distance) {
-            GeoCoord p2 = new GeoCoord(p1);
+            GeoCoord p2 = new(p1);
             if (distance < EPSILON) return p2;
 
             double az = NormalizeAngle(azimuth);
@@ -205,7 +205,7 @@ namespace H3.Model {
 
         public bool AlmostEquals(GeoCoord p2) => AlmostEqualsThreshold(p2, EPSILON_RAD);
 
-        public static implicit operator GeoCoord((double, double) c) => new GeoCoord(c.Item1, c.Item2);
+        public static implicit operator GeoCoord((double, double) c) => new(c.Item1, c.Item2);
 
         public static bool operator ==(GeoCoord a, GeoCoord b) => a.Latitude == b.Latitude && a.Longitude == b.Longitude;
 

--- a/src/H3/Model/Vec2d.cs
+++ b/src/H3/Model/Vec2d.cs
@@ -24,8 +24,8 @@ namespace H3.Model {
         }
 
         public static Vec2d Intersect(Vec2d p0, Vec2d p1, Vec2d p2, Vec2d p3) {
-            Vec2d s1 = new Vec2d(p1.X - p0.X, p1.Y - p0.Y);
-            Vec2d s2 = new Vec2d(p3.X - p2.X, p3.Y - p2.Y);
+            Vec2d s1 = new(p1.X - p0.X, p1.Y - p0.Y);
+            Vec2d s2 = new(p3.X - p2.X, p3.Y - p2.Y);
             float t = (float)(s2.X * (p0.Y - p2.Y) - s2.Y * (p0.X - p2.X)) /
                 (float)(-s2.X * s1.Y + s1.X * s2.Y);
             return new Vec2d(p0.X + (t * s1.X), p0.Y + (t * s1.Y));

--- a/src/H3/Utils.cs
+++ b/src/H3/Utils.cs
@@ -1,24 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using NetTopologySuite.Geometries;
 using static H3.Constants;
 
 namespace H3 {
     public static class Utils {
         public static readonly GeometryFactory DefaultGeometryFactory =
-            new GeometryFactory(new PrecisionModel(1 / EPSILON), 4326);
+            new(new PrecisionModel(1 / EPSILON), 4326);
 
         public static bool IsFinite(this double d) => !double.IsInfinity(d) && !double.IsNaN(d);
-
-        public static long IPow(long b, long exp) {
-            long result = 1;
-            while (exp != 0) {
-                if ((exp & 1) != 0) result += b;
-                exp >>= 1;
-                b *= b;
-            }
-            return result;
-        }
 
         public static double Square(double v) => v * v;
 
@@ -26,11 +17,6 @@ namespace H3 {
             double tmp = radians < 0 ? radians + M_2PI : radians;
             if (radians >= M_2PI) tmp -= M_2PI;
             return tmp;
-        }
-
-        public static double ConstrainLatitude(double latitude) {
-            while (latitude > M_PI_2) latitude -= M_PI;
-            return latitude;
         }
 
         public static double ConstrainLongitude(double longitude) {
@@ -50,13 +36,22 @@ namespace H3 {
             return 4 * Math.Atan(Math.Sqrt(Math.Tan(s) * Math.Tan(a) * Math.Tan(b) * Math.Tan(c)));
         }
 
+        /// <summary>
+        /// Indicates whether or not the provided resolution has a Class 3 orientation.
+        /// </summary>
+        /// <param name="resolution"></param>
+        /// <returns></returns>
         public static bool IsResolutionClass3(int resolution) => (resolution % 2) != 0;
 
+        /// <summary>
+        /// Indicates whether or not the specified child resolution is valid relative to the
+        /// provided parent resolution.
+        /// </summary>
+        /// <param name="parentResolution"></param>
+        /// <param name="childResolution"></param>
+        /// <returns></returns>
         public static bool IsValidChildResolution(int parentResolution, int childResolution) =>
             childResolution >= parentResolution && childResolution <= MAX_H3_RES;
 
-        public static IEnumerable<T> ToEnumerable<T>(this T item) {
-            yield return item;
-        }
     }
 }

--- a/test/H3.Benchmarks/Extensions/HierarchyExtensionBenchmarks.cs
+++ b/test/H3.Benchmarks/Extensions/HierarchyExtensionBenchmarks.cs
@@ -29,5 +29,11 @@ namespace H3.Benchmarks.Extensions {
         [Benchmark(Description = "H3Lib.ToChildren")]
         public List<H3Lib.H3Index> H3LibGetChildrenForResolution() => H3LibTestIndex.ToChildren(resolution).ToList();
 
+        [Benchmark(Description = "pocketken.H3.GetParentForResolution")]
+        public H3Index GetParentForResolution() => TestHelpers.SfIndex.GetParentForResolution(0);
+
+        [Benchmark(Description = "H3Lib.ToParent")]
+        public H3Lib.H3Index H3LibGetParentForResolution() => H3LibTestIndex.ToParent(0);
+
     }
 }

--- a/test/H3.Test/Algorithms/PolyfillTests.cs
+++ b/test/H3.Test/Algorithms/PolyfillTests.cs
@@ -180,19 +180,19 @@ namespace H3.Test.Algorithms {
             // Arrange
             var index = H3Index.Create(9, 24, 0);
             GeoCoord coord = index.ToGeoCoord();
-            GeoCoord topRight = new GeoCoord {
+            GeoCoord topRight = new() {
                 Latitude = coord.Latitude + EdgeLength2,
                 Longitude = coord.Longitude + EdgeLength2
             };
-            GeoCoord topLeft = new GeoCoord {
+            GeoCoord topLeft = new() {
                 Latitude = coord.Latitude + EdgeLength2,
                 Longitude = coord.Longitude - EdgeLength2
             };
-            GeoCoord bottomRight = new GeoCoord {
+            GeoCoord bottomRight = new() {
                 Latitude = coord.Latitude - EdgeLength2,
                 Longitude = coord.Longitude + EdgeLength2
             };
-            GeoCoord bottomLeft = new GeoCoord {
+            GeoCoord bottomLeft = new() {
                 Latitude = coord.Latitude - EdgeLength2,
                 Longitude = coord.Longitude - EdgeLength2
             };

--- a/test/H3.Test/Extensions/H3GeometryExtensionsTests.cs
+++ b/test/H3.Test/Extensions/H3GeometryExtensionsTests.cs
@@ -108,7 +108,7 @@ namespace H3.Test.Extensions {
         [Test]
         public void Test_GetCellBoundaryVertices_AtRes0() {
             // Arrange
-            GeoCoord c = new GeoCoord(0, 0);
+            GeoCoord c = new(0, 0);
             var index = H3Index.FromGeoCoord(c, 0);
 
             // Act
@@ -169,7 +169,7 @@ namespace H3.Test.Extensions {
         [Test]
         public void Test_GetCellAreaInKm2() {
             // Arrange
-            GeoCoord c = new GeoCoord(0, 0);
+            GeoCoord c = new(0, 0);
             var indexes = Enumerable.Range(0, MAX_H3_RES + 1).Select(r => H3Index.FromGeoCoord(c, r)).ToArray();
 
             // Act

--- a/test/H3.Test/Extensions/H3HierarchyExtensionsTests.cs
+++ b/test/H3.Test/Extensions/H3HierarchyExtensionsTests.cs
@@ -193,11 +193,10 @@ namespace H3.Test.Extensions {
         [TestCase(Direction.IJ, 8, 1)]
         public void Test_GetDirectNeighbour_BaseCells(Direction direction, int expectedBaseCell, int baseRotations) {
             // Arrange
-            int rotations = 0;
             int expectedRotations = LookupTables.BaseCells[expectedBaseCell].IsPentagon ? baseRotations + 1 : baseRotations;
 
             // Act
-            var actual = BaseCell0.GetDirectNeighbour(direction, ref rotations);
+            var (actual, rotations) = BaseCell0.GetDirectNeighbour(direction);
 
             // Assert
             Assert.AreEqual(expectedBaseCell, actual.BaseCellNumber, $"should be {expectedBaseCell}");
@@ -239,8 +238,7 @@ namespace H3.Test.Extensions {
         [Test]
         public void Test_Upstream_IsNeighbour_FalseOnInvalid() {
             // Arrange
-            int rotations = 0;
-            H3Index index = new(TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ, ref rotations)) {
+            H3Index index = new(TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ).Item1) {
                 Mode = Mode.UniEdge
             };
 
@@ -254,8 +252,7 @@ namespace H3.Test.Extensions {
         [Test]
         public void Test_Upstream_IsNeighbour_FalseOnResolutionDifference() {
             // Arrange
-            int rotations = 0;
-            H3Index index = new(TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ, ref rotations));
+            H3Index index = new(TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ).Item1);
 
             // Act
             var actual = TestHelpers.SfIndex.IsNeighbour(index.GetParentForResolution(7));

--- a/test/H3.Test/Extensions/H3LocalIJExtensionsTests.cs
+++ b/test/H3.Test/Extensions/H3LocalIJExtensionsTests.cs
@@ -234,7 +234,7 @@ namespace H3.Test.Extensions {
             // Act
             var coords = TestHelpers.GetAllCellsForResolution(2)
                 .Select(index => {
-                    CoordIJK expected = new CoordIJK(LookupTables.DirectionToUnitVector[index.GetDirectionForResolution(1)]);
+                    CoordIJK expected = new(LookupTables.DirectionToUnitVector[index.GetDirectionForResolution(1)]);
                     expected.DownAperature7Clockwise().ToNeighbour(index.GetDirectionForResolution(2));
 
                     return (
@@ -262,8 +262,7 @@ namespace H3.Test.Extensions {
                     Enumerable.Range((int)Direction.K, 6)
                         .Where(dir => !(index.IsPentagon && dir == (int)Direction.K))
                         .Select(dir => {
-                            int rotations = 0;
-                            H3Index offset = index.GetDirectNeighbour((Direction)dir, ref rotations);
+                            H3Index offset = index.GetDirectNeighbour((Direction)dir).Item1;
                             return (
                                 Origin: index,
                                 OriginIJK: index.ToLocalIJK(index),

--- a/test/H3.Test/Extensions/H3UniEdgeExtensionsTests.cs
+++ b/test/H3.Test/Extensions/H3UniEdgeExtensionsTests.cs
@@ -32,8 +32,7 @@ namespace H3.Test.Extensions {
                 Mode = Mode.UniEdge,
                 ReservedBits = (int)Direction.IJ
             };
-            int rotations = 0;
-            H3Index destination = origin.GetDirectNeighbour(Direction.IJ, ref rotations);
+            H3Index destination = origin.GetDirectNeighbour(Direction.IJ).Item1;
 
             // Act
             var actual = origin.GetUnidirectionalEdge(destination);
@@ -145,8 +144,7 @@ namespace H3.Test.Extensions {
         [Test]
         public void Test_Upstream_GetOriginFromUnidirectionalEdge() {
             // Arrange
-            int rotations = 0;
-            H3Index sf2 = TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ, ref rotations);
+            H3Index sf2 = TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ).Item1;
             var edge = TestHelpers.SfIndex.GetUnidirectionalEdge(sf2);
 
             // Act
@@ -177,8 +175,7 @@ namespace H3.Test.Extensions {
         [Test]
         public void Test_Upstream_GetDestinationFromUnidirectionalEdge() {
             // Arrange
-            int rotations = 0;
-            H3Index sf2 = TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ, ref rotations);
+            H3Index sf2 = TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ).Item1;
             var edge = TestHelpers.SfIndex.GetUnidirectionalEdge(sf2);
 
             // Act
@@ -209,8 +206,7 @@ namespace H3.Test.Extensions {
         [Test]
         public void Test_Upstream_GetIndexesFromUnidirectionalEdge() {
             // Arrange
-            int rotations = 0;
-            H3Index sf2 = TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ, ref rotations);
+            H3Index sf2 = TestHelpers.SfIndex.GetDirectNeighbour(Direction.IJ).Item1;
             var edge = TestHelpers.SfIndex.GetUnidirectionalEdge(sf2);
 
             // Act

--- a/test/H3.Test/H3IndexTests.cs
+++ b/test/H3.Test/H3IndexTests.cs
@@ -75,7 +75,7 @@ namespace H3.Test {
         [Test]
         public void Test_KnownIndexValue() {
             // Act
-            H3Index h3 = new H3Index(TestHelpers.TestIndexValue);
+            H3Index h3 = new(TestHelpers.TestIndexValue);
 
             // Assert
             AssertKnownIndexValue(h3);
@@ -84,7 +84,7 @@ namespace H3.Test {
         [Test]
         public void Test_FromString_MatchesKnownIndexValue() {
             // Act
-            H3Index h3 = new H3Index("8e48e1d7038d527");
+            H3Index h3 = new("8e48e1d7038d527");
 
             // Assert
             AssertKnownIndexValue(h3);
@@ -93,7 +93,7 @@ namespace H3.Test {
         [Test]
         public void Test_FromPoint_MatchesKnownIndexValue() {
             // Arrange
-            Point point = new Point(-110, 30);
+            Point point = new(-110, 30);
 
             // Act
             H3Index h3 = H3Index.FromPoint(point, 14);
@@ -105,10 +105,10 @@ namespace H3.Test {
         [Test]
         public void Test_Equality() {
             // Arrange
-            H3Index i1 = new H3Index(TestHelpers.TestIndexValue);
-            H3Index i1_1 = new H3Index(TestHelpers.TestIndexValue);
-            H3Index i2 = new H3Index(TestHelpers.TestIndexValue + 1);
-            H3Index i2_2 = new H3Index(TestHelpers.TestIndexValue + 1);
+            H3Index i1 = new(TestHelpers.TestIndexValue);
+            H3Index i1_1 = new(TestHelpers.TestIndexValue);
+            H3Index i2 = new(TestHelpers.TestIndexValue + 1);
+            H3Index i2_2 = new(TestHelpers.TestIndexValue + 1);
             List<H3Index> h3List = new() { i1, i2 };
             HashSet<H3Index> h3Set = new() { i1, i2 };
 

--- a/test/H3.Test/Model/CoordIJKTests.cs
+++ b/test/H3.Test/Model/CoordIJKTests.cs
@@ -21,7 +21,7 @@ namespace H3.Test {
         [TestCase(8, 1, 8, Direction.Invalid)]
         public void Test_CoordIJK_UnitVector_Matching(int i, int j, int k, Direction expectedIndex) {
             // Arrange
-            CoordIJK coord = new CoordIJK(i, j, k);
+            CoordIJK coord = new(i, j, k);
 
             // Act
             var cell = (Direction)coord;
@@ -34,7 +34,7 @@ namespace H3.Test {
         [TestCase(0, 1, 0, 2)]
         public void Test_CoordIJK_Equals(int i, int j, int k, int expectedIndex) {
             // Arrange
-            CoordIJK coord = new CoordIJK(i, j, k);
+            CoordIJK coord = new(i, j, k);
 
             // Act
             var result = coord == LookupTables.UnitVectors[expectedIndex];
@@ -46,8 +46,8 @@ namespace H3.Test {
         [Test]
         public void Test_CoordIJK_Addition() {
             // Arrange
-            CoordIJK a = new CoordIJK(1, 1, 0);
-            CoordIJK b = new CoordIJK(0, 1, 1);
+            CoordIJK a = new(1, 1, 0);
+            CoordIJK b = new(0, 1, 1);
 
             // Act
             var result = a + b;
@@ -61,8 +61,8 @@ namespace H3.Test {
         [Test]
         public void Test_CoordIJK_Subtraction() {
             // Arrange
-            CoordIJK a = new CoordIJK(1, 1, 0);
-            CoordIJK b = new CoordIJK(0, 1, 1);
+            CoordIJK a = new(1, 1, 0);
+            CoordIJK b = new(0, 1, 1);
 
             // Act
             var result = a - b;
@@ -76,7 +76,7 @@ namespace H3.Test {
         [Test]
         public void Test_CoordIJK_Scaling() {
             // Arrange
-            CoordIJK a = new CoordIJK(1, 1, 0);
+            CoordIJK a = new(1, 1, 0);
 
             // Act
             var result = a *= 2;
@@ -90,9 +90,9 @@ namespace H3.Test {
         [Test]
         public void Test_CoordIJK_MultipleTransforms() {
             // Arrange
-            CoordIJK a = new CoordIJK(1, 1, 0);
-            CoordIJK b = new CoordIJK(0, 1, 1);
-            CoordIJK c = new CoordIJK(1, 0, 0);
+            CoordIJK a = new(1, 1, 0);
+            CoordIJK b = new(0, 1, 1);
+            CoordIJK c = new(1, 0, 0);
 
             // Act
             var result = (a + b + c) * 2;
@@ -106,7 +106,7 @@ namespace H3.Test {
         [Test]
         public void Test_CoordIJK_Normalize() {
             // Arrange
-            CoordIJK a = new CoordIJK(-2, 2, 0);
+            CoordIJK a = new(-2, 2, 0);
 
             // Act
             var result = CoordIJK.Normalize(a);
@@ -123,7 +123,7 @@ namespace H3.Test {
         [TestCase(Direction.Invalid, 0, 0, 0)]
         public void Test_CoordIJK_ToNeighbour(Direction direction, int expectedI, int expectedJ, int expectedK) {
             // Arrange
-            CoordIJK ijk = new CoordIJK();
+            CoordIJK ijk = new();
 
             // Act
             var neighbour = ijk.ToNeighbour(direction);


### PR DESCRIPTION
* get rid of `ref int` parameter on `GetDirectNeighbour` and instead return the new number of rotations in a tuple along with the generated index
* add new `InvalidateDirectionsForResolutionRange` to invalidate a range of direction digits without looping, similar to the zero one we added as part of the upstream iterator PR.  yay another few ns!
* get rid of some unused methods
* IDE0090
* updates to benchmark numbers