### PR TITLE
bugfix GH-26: support serialization w/System.Text.Json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,27 @@
+# pocketken.H3 Change Log
+
+### 3.7.1.3 - 2021-04-22
+
+##### Enhancements :tada:
+
+- Minor performance optimizations, slight API adjustments (sorry!)  [#24](https://github.com/pocketken/H3.net/pull/24)
+
+##### Fixes :wrench:
+
+- Fixes issues serializing to JSON using `System.Text.Json`.  [#26](https://github.com/pocketken/H3.net/issues/26)
+
+### 3.7.1.2 - 2021-03-26
+
+##### Fixes :wrench:
+
+- Fixes `DefaultGeometryFactory` to use EPSG 4326, not 4236.  [#22](https://github.com/pocketken/H3.net/issues/22)
+
+### 3.7.1.1 - 2021-03-23
+
+##### Fixes :wrench:
+
+- Updates NTS dependency from NetTopologySuite.Core 1.x to NetTopologySuite 2.x.  [#20](https://github.com/pocketken/H3.net/issues/20)
+
+### 3.7.1.0 - 2021-03-23
+
+Initial nuget package release.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ PRs to improve code, tests and documentation are definitely welcome, although pl
 Available on [nuget.org](https://nuget.org) as [pocketken.H3](https://www.nuget.org/packages/pocketken.H3/).
 
 ```
-PM> Install-Package pocketken.H3 -Version 3.7.1.2
+PM> Install-Package pocketken.H3 -Version 3.7.1.3
 ```
+
+See [CHANGES.md](CHANGES.md) for a list of changes between releases.
 
 ## Some Mostly-Pointless Benchmarks
 There is an extremely basic set of benchmarks using [BenchmarkDotNet](https://benchmarkdotnet.org/index.html) that I have begun to use in order to track performance and perform optimizations as things progress.  You can check the code out to run the benchmarks locally if you want, e.g.:

--- a/src/H3/H3.csproj
+++ b/src/H3/H3.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyName>pocketken.H3.3.7.1.2</AssemblyName>
+    <AssemblyName>pocketken.H3.3.7.1.3</AssemblyName>
     <TargetFramework>net5.0</TargetFramework>
     <PackOnBuild>true</PackOnBuild>
     <PackageId>pocketken.H3</PackageId>
-    <PackageVersion>3.7.1.2</PackageVersion>
+    <PackageVersion>3.7.1.3</PackageVersion>
     <Authors>pocketken</Authors>
     <Description>Port of Uber's H3 to .NET</Description>
     <PackageProjectUrl>https://github.com/pocketken/H3.net</PackageProjectUrl>
@@ -14,11 +14,11 @@
     <Company />
     <IsPackable>true</IsPackable>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>3.7.1.2</Version>
+    <Version>3.7.1.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Dev\H3.net\src\H3\pocketken.H3.3.7.1.2.xml</DocumentationFile>
+    <DocumentationFile>C:\Dev\H3.net\src\H3\pocketken.H3.3.7.1.3.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/H3/H3Index.cs
+++ b/src/H3/H3Index.cs
@@ -5,11 +5,13 @@ using static H3.Constants;
 using static H3.Utils;
 using NetTopologySuite.Geometries;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
 namespace H3 {
 
+    [JsonConverter(typeof(H3IndexJsonConverter))]
     public class H3Index : IComparable<H3Index> {
 
         #region constants

--- a/src/H3/H3IndexJsonConverter.cs
+++ b/src/H3/H3IndexJsonConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace H3 {
+
+    /// <summary>
+    /// Handles (de)serialization of H3Index values to/from JSON using
+    /// System.Text.Json.
+    /// </summary>
+    public class H3IndexJsonConverter : JsonConverter<H3Index> {
+
+        /// <inheritdoc/>
+        public override H3Index Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException("Expected string");
+
+            return new H3Index(reader.GetString());
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, H3Index value, JsonSerializerOptions options) {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+
+}

--- a/test/H3.Test/H3.Test.csproj
+++ b/test/H3.Test/H3.Test.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/H3.Test/H3IndexTests.cs
+++ b/test/H3.Test/H3IndexTests.cs
@@ -8,6 +8,7 @@ using NetTopologySuite.Geometries;
 using NUnit.Framework;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Text.Json;
 
 namespace H3.Test {
 
@@ -161,6 +162,52 @@ namespace H3.Test {
 
             return true;
         }
+
+        [Test]
+        public void Test_Serialization_ToJson() {
+            // Arrange
+            var expected = $@"""{TestHelpers.SfIndex}""";
+
+
+            // Act
+            var result = JsonSerializer.Serialize(TestHelpers.SfIndex);
+
+            // Assert
+            Assert.IsNotNull(result, "should not be null");
+            Assert.AreEqual(expected, result, "should serialize to hex string");
+        }
+
+        [Test]
+        public void Test_Serialization_FromJson() {
+            // Arrange
+            var indexJson = $@"""{TestHelpers.SfIndex}""";
+
+            // Act
+            var result = JsonSerializer.Deserialize<H3Index>(indexJson);
+
+            // Assert
+            Assert.AreEqual(TestHelpers.SfIndex, result, "should be equal");
+        }
+
+        internal record SerializationTest {
+            public int SomeOtherProperty { get; set; }
+            public H3Index Index { get; set; }
+        }
+
+        [Test]
+        public void Test_Serialization_ToFromJsonObject() {
+            // Arrange
+            var record = new SerializationTest { Index = TestHelpers.SfIndex, SomeOtherProperty = 242 };
+            var indexJson = JsonSerializer.Serialize(record);
+
+            // Act
+            var result = JsonSerializer.Deserialize<SerializationTest>(indexJson);
+
+            // Assert
+            Assert.AreEqual(242, result.SomeOtherProperty, "should have sentinel value");
+            Assert.AreEqual(TestHelpers.SfIndex, result.Index, "should be equal");
+        }
+
 
         private static void AssertKnownIndexValue(H3Index h3) {
             Assert.IsTrue(TestHelpers.TestIndexValue == h3, "ulong value should equal H3Index");


### PR DESCRIPTION
Fixes #26.

- adds `JsonConverter` for `H3Index`
- adds tests
- might as well start a changelog...