### PR TITLE
Fix "ambiguous reference" errors due to emitted code

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,10 +33,8 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    # note: we disable parallel builds to prevent spurious
-    # build failures w/code generator
     - name: Build
-      run: dotnet build --no-restore /m:1
+      run: dotnet build --no-restore
 
     - name: Test
       run: dotnet test --no-build --verbosity normal

--- a/src/H3/H3.csproj
+++ b/src/H3/H3.csproj
@@ -22,11 +22,6 @@
     <DocumentationFile>pocketken.H3.3.7.2.1.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>$(MSBuildThisFileDirectory)/Generated</CompilerGeneratedFilesOutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="NetTopologySuite" Version="2.4.0" />
   </ItemGroup>
@@ -48,17 +43,6 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Analyzer</OutputItemType>
     </ProjectReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Don't include the output from a previous source generator execution into future runs; the */** trick here ensures that there's
-    at least one subdirectory, which is our key that it's coming from a source generator as opposed to something that is coming from
-    some other tool. -->
-    <Compile Remove="$(CompilerGeneratedFilesOutputPath)/*/**/*.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Algorithms\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes build to no longer emit generated code (don't need it now that its done + working).  Hopefully also enables reliable parallel builds in GH actions...